### PR TITLE
Add support to generate URL for addoptionbundles

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ const
 	PARAMETERS = {
 		all: ["l", "contactid", "skinid", "orderid", "returnurl"],
 		addtickets: ["event", "product", "flow", "reservemoretickets", "saleschannelid", "ticketinfo", "extraevents", "extraproducts", "edit", "panels", "oncompletion", "withauthentication"],
+		addoptionbundles: ["event", "product", "flow", "reservemoretickets", "saleschannelid", "ticketinfo", "edit", "panels", "oncompletion", "withauthentication"],
 		basket: ["flow", "edit", "reservemoretickets", "panels", "oncompletion"],
 		checkout: ["panels", "oncompletion"]
 	},


### PR DESCRIPTION
Added support to generate a URL for `addoptionbundles`, i.e. a URL starting with `https://apps.ticketmatic.com/widgets/[shortname]/addoptionbundles?`.