### PR TITLE
New widget type: subscribe

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@ const
 		addtickets: ["event", "product", "flow", "reservemoretickets", "saleschannelid", "ticketinfo", "extraevents", "extraproducts", "edit", "panels", "oncompletion", "withauthentication"],
 		addoptionbundles: ["event", "product", "flow", "reservemoretickets", "saleschannelid", "ticketinfo", "edit", "panels", "oncompletion", "withauthentication"],
 		basket: ["flow", "edit", "reservemoretickets", "panels", "oncompletion"],
-		checkout: ["panels", "oncompletion"]
+		checkout: ["panels", "oncompletion"],
+		subscribe: ["fields", "requiredfields", "customfields"]
 	},
 
 	filterWithKeys = (pred, obj) => R.pipe(

--- a/index.js
+++ b/index.js
@@ -31,6 +31,8 @@ const
 
 	concatFields = R.pipe(R.dissoc("l"), R.filter(hasValue), R.toPairs, R.sortBy(R.head), R.flatten, R.join('')),
 
+	joinArrays = R.map(R.when(R.is(Array), R.join(',')), R.__),
+
 	generatePayload = (accesskey, accountname, properties) => R.join('', [accesskey, accountname, concatFields(properties)]),
 
 	generateSignature = (accesskey, accountname, properties, secret) => {
@@ -50,7 +52,7 @@ module.exports = {
 			throw new Error("Some values are incorrect, cannot generate URL");
 		}
 
-		let validproperties = filterWithKeys(validProperty(widgettype))(properties),
+		let validproperties = joinArrays(filterWithKeys(validProperty(widgettype))(properties)),
 			signature = generateSignature(client.key, client.shortname, validproperties, client.secret),
         	_parameters = R.merge(validproperties, {accesskey: client.key, signature: signature}),
         	query = querystring.stringify(_parameters)


### PR DESCRIPTION
Added support for the new `subscribe` widget, closes #4 

The widget can be created as described in the issue. But as of now the code does not (at least I think so) properly support arrays as input, for example `fields: ["customertitle", "address"]` will output an URL containing `&fields=customertitle&fields=address` instead of `&fields=customertitle,address`, is that correct?

Also added a system that checks if the values for the parameters are valid throwing an error if that is not the case(?). As of now this code only works when the `fields` and `requiredfields` are declared as an array, should we support strings as well?